### PR TITLE
Add homepage navigation and default homepage handling

### DIFF
--- a/assets/javascripts/discourse/initializers/discourse-voting.js.es6
+++ b/assets/javascripts/discourse/initializers/discourse-voting.js.es6
@@ -1,5 +1,6 @@
 import I18n from "I18n";
 import { withPluginApi } from "discourse/lib/plugin-api";
+import { setDefaultHomepage } from "discourse/lib/utilities";
 import NavItem from "discourse/models/nav-item";
 
 export default {
@@ -18,11 +19,17 @@ export default {
           term: "order:votes",
         });
 
+        const topMenuItems = siteSettings.top_menu.split('|');
+        const votesBeforeNavItem = siteSettings.voting_show_votes_before;
+        if (topMenuItems.indexOf(votesBeforeNavItem) === 0) {
+          setDefaultHomepage('votes');
+        }
+
         api.addNavigationBarItem({
           name: "votes",
-          before: "top",
+          before: votesBeforeNavItem,
           customFilter: (category) => {
-            return category && category.can_vote;
+            return (!category && siteSettings.voting_show_votes_on_homepage) || (category && category.can_vote);
           },
           customHref: (category, args) => {
             const path = NavItem.pathFor("latest", args);

--- a/assets/javascripts/discourse/pre-initializers/extend-category-for-voting.js.es6
+++ b/assets/javascripts/discourse/pre-initializers/extend-category-for-voting.js.es6
@@ -1,5 +1,6 @@
 import I18n from "I18n";
 import { withPluginApi } from "discourse/lib/plugin-api";
+import discourseComputed from "discourse-common/utils/decorators";
 
 function initialize(api) {
   api.addPostClassesCallback((post) => {
@@ -44,6 +45,19 @@ export default {
 
   initialize() {
     withPluginApi("0.8.4", (api) => initialize(api));
-    withPluginApi("0.8.30", (api) => api.addCategorySortCriteria("votes"));
+    withPluginApi("0.8.30", (api) => {
+      api.addCategorySortCriteria("votes");
+      api.modifyClass("component:edit-category-settings", {
+        pluginId: "discourse-voting",
+
+        @discourseComputed
+        availableViews() {
+          return [...this._super(...arguments), {
+            name: I18n.t("filters.votes.title"),
+            value: "votes"
+          }];
+        }
+      })
+    });
   },
 };

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -8,6 +8,8 @@ en:
     voting_tl4_vote_limit: 'How many active votes are TL4 users allowed?'
     voting_show_who_voted: 'Allow users to see who voted?'
     voting_show_votes_on_profile: 'Allow users to see their votes in their activity feed?'
+    voting_show_votes_on_homepage: 'Show vote list navigation item on homepage?'
+    voting_show_votes_before: 'Show vote list navgiation item before this navigation item'
     voting_alert_votes_left: 'Alert user when this many votes are left'
   voting:
     votes_moved:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -9,7 +9,9 @@ en:
     voting_show_who_voted: 'Allow users to see who voted?'
     voting_show_votes_on_profile: 'Allow users to see their votes in their activity feed?'
     voting_show_votes_on_homepage: 'Show vote list navigation item on homepage?'
+    voting_show_my_votes_on_homepage: 'Show my vote list navgiation item on homepage?'
     voting_show_votes_before: 'Show vote list navgiation item before this navigation item'
+    voting_show_my_votes_before: 'Show my vote list navgiation item before this navigation item'
     voting_alert_votes_left: 'Alert user when this many votes are left'
   voting:
     votes_moved:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,7 +13,24 @@ plugins:
   voting_show_votes_on_homepage:
     default: false
     client: true
+  voting_show_my_votes_on_homepage:
+    default: false
+    client: true
   voting_show_votes_before:
+    default: top
+    client: true
+    type: enum
+    choices:
+      - latest
+      - new
+      - unread
+      - unseen
+      - top
+      - categories
+      - read
+      - posted
+      - bookmarks
+  voting_show_my_votes_before:
     default: top
     client: true
     type: enum

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,6 +10,23 @@ plugins:
   voting_show_votes_on_profile:
     default: true
     client: true
+  voting_show_votes_on_homepage:
+    default: false
+    client: true
+  voting_show_votes_before:
+    default: top
+    client: true
+    type: enum
+    choices:
+      - latest
+      - new
+      - unread
+      - unseen
+      - top
+      - categories
+      - read
+      - posted
+      - bookmarks
   voting_tl0_vote_limit:
     default: 2
   voting_tl1_vote_limit:

--- a/plugin.rb
+++ b/plugin.rb
@@ -85,7 +85,7 @@ after_initialize do
           sort_dir = (options[:ascending] == "true") ? "ASC" : "DESC"
           result = result
             .joins("LEFT JOIN discourse_voting_topic_vote_count ON discourse_voting_topic_vote_count.topic_id = topics.id")
-            .reorder("COALESCE(discourse_voting_topic_vote_count.votes_count,'0')::integer #{sort_dir}")
+            .reorder("COALESCE(discourse_voting_topic_vote_count.votes_count,'0')::integer #{sort_dir}, topics.bumped_at DESC")
         end
 
         result


### PR DESCRIPTION
Adds settings that allow you to use the ``votes`` and ``my votes`` lists on the homepage.

Note that ``/votes`` and ``/latest?order=votes`` currently return different results, partly because the topic list version has a secondary order attribute ``topics.bumped_at``. I've added that as a secondary attribute to the ``/votes`` list.