### PR TITLE
DEV: Rename `has_one :category_setting` as it clashes with core

### DIFF
--- a/lib/discourse_topic_voting/categories_controller_extension.rb
+++ b/lib/discourse_topic_voting/categories_controller_extension.rb
@@ -8,11 +8,11 @@ module DiscourseTopicVoting
 
       category_params = super
 
-      if @vote_enabled && !@category&.category_setting
-        category_params[:category_setting_attributes] = {}
-      elsif !@vote_enabled && @category&.category_setting
-        category_params[:category_setting_attributes] = {
-          id: @category.category_setting.id,
+      if @vote_enabled && !@category&.discourse_topic_voting_category_setting
+        category_params[:discourse_topic_voting_category_setting_attributes] = {}
+      elsif !@vote_enabled && @category&.discourse_topic_voting_category_setting
+        category_params[:discourse_topic_voting_category_setting_attributes] = {
+          id: @category.discourse_topic_voting_category_setting.id,
           _destroy: "1",
         }
       end

--- a/lib/discourse_topic_voting/category_extension.rb
+++ b/lib/discourse_topic_voting/category_extension.rb
@@ -4,18 +4,20 @@ module DiscourseTopicVoting
   module CategoryExtension
     def self.prepended(base)
       base.class_eval do
-        has_one :category_setting,
+        has_one :discourse_topic_voting_category_setting,
                 class_name: "DiscourseTopicVoting::CategorySetting",
                 dependent: :destroy
 
-        accepts_nested_attributes_for :category_setting, allow_destroy: true
+        accepts_nested_attributes_for :discourse_topic_voting_category_setting, allow_destroy: true
 
         after_save :reset_voting_cache
 
         @allowed_voting_cache = DistributedCache.new("allowed_voting")
 
         def self.reset_voting_cache
-          @allowed_voting_cache["allowed"] = CategorySetting.pluck(:category_id)
+          @allowed_voting_cache["allowed"] = DiscourseTopicVoting::CategorySetting.pluck(
+            :category_id,
+          )
         end
 
         def self.can_vote?(category_id)

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -19,6 +19,7 @@ describe CategoriesController do
             "enable_topic_voting" => true,
           },
         }
+
     expect(Category.can_vote?(category.id)).to eq(true)
   end
 


### PR DESCRIPTION
What is the problem?

Discourse core already declares a `has_one :category_setting`
association so this plugin is overriding that association which is not
what we want.

What is the solution?

Since this plugin adds a category setting model of its own, we can
simply rename the association to avoid the conflict with core.