### PR TITLE
DEV: Add inverse declaration for  association

### DIFF
--- a/app/models/discourse_topic_voting/category_setting.rb
+++ b/app/models/discourse_topic_voting/category_setting.rb
@@ -4,7 +4,7 @@ module DiscourseTopicVoting
   class CategorySetting < ActiveRecord::Base
     self.table_name = "discourse_voting_category_settings"
 
-    belongs_to :category
+    belongs_to :category, inverse_of: :discourse_topic_voting_category_setting
 
     before_create :unarchive_votes
     before_destroy :archive_votes

--- a/spec/models/discourse_voting/category_setting_spec.rb
+++ b/spec/models/discourse_voting/category_setting_spec.rb
@@ -4,6 +4,8 @@ require "rails_helper"
 describe DiscourseTopicVoting::CategorySetting do
   fab!(:category) { Fabricate(:category) }
 
+  it { is_expected.to belong_to(:category).inverse_of(:discourse_topic_voting_category_setting) }
+
   describe "logs category setting changes" do
     it "logs changes when voting is enabled/disabled" do
       DiscourseTopicVoting::CategorySetting.create!(category: category)


### PR DESCRIPTION
Follow-up to #148.

Without this inverse declaration ActiveRecord gets confused in the presence of two `CategorySetting` classes.

### Before

<img width="913" alt="Screenshot 2023-03-07 at 12 54 21 PM" src="https://user-images.githubusercontent.com/5259935/223324226-a653a91d-5700-4e28-9138-2fd72ac883d6.png">

### After

<img width="592" alt="Screenshot 2023-03-07 at 12 53 57 PM" src="https://user-images.githubusercontent.com/5259935/223324236-0e2c9bd7-1c72-49d2-89fc-4f8e05451779.png">
