### PR TITLE
FIX: Don't remove custom fields when adding a new one to category serializer

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -94,7 +94,9 @@ after_initialize do
     end
   end
 
-  add_to_serializer(:category, :custom_fields) do
+  add_to_serializer(:category, :custom_fields, false) do
+    return object.custom_fields if !SiteSetting.voting_enabled
+
     object.custom_fields.merge(
       enable_topic_voting:
         DiscourseTopicVoting::CategorySetting.find_by(category_id: object.id).present?,

--- a/spec/serializers/category_serializer_spec.rb
+++ b/spec/serializers/category_serializer_spec.rb
@@ -18,6 +18,6 @@ describe CategorySerializer do
 
     json = CategorySerializer.new(category, root: false).as_json
 
-    expect(json[:custom_fields]).to eq({ enable_topic_voting: true })
+    expect(json[:custom_fields]).to eq({ "enable_topic_voting" => false })
   end
 end

--- a/spec/serializers/category_serializer_spec.rb
+++ b/spec/serializers/category_serializer_spec.rb
@@ -13,7 +13,7 @@ describe CategorySerializer do
     expect(json[:custom_fields]).to eq({})
   end
 
-  it "return enable_topic_voting when voting enabled" do
+  it "returns enable_topic_voting when voting enabled" do
     SiteSetting.voting_enabled = true
 
     json = CategorySerializer.new(category, root: false).as_json

--- a/spec/serializers/category_serializer_spec.rb
+++ b/spec/serializers/category_serializer_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe CategorySerializer do
+  fab!(:category) { Fabricate(:category) }
+
+  it "does not return enable_topic_voting voting disabled" do
+    SiteSetting.voting_enabled = false
+
+    json = CategorySerializer.new(category, root: false).as_json
+
+    expect(json[:custom_fields]).to eq({})
+  end
+
+  it "return enable_topic_voting when voting enabled" do
+    SiteSetting.voting_enabled = true
+
+    json = CategorySerializer.new(category, root: false).as_json
+
+    expect(json[:custom_fields]).to eq({ enable_topic_voting: true })
+  end
+end


### PR DESCRIPTION
Currently, if a hoster has this plugin installed but disabled, they will get no Category custom fields, which is bad.

What this means is that despite checking this option in category settings, this bug will cause it not to be shown as checked.

<img width="680" alt="Screenshot 2023-03-30 at 12 26 10 PM" src="https://user-images.githubusercontent.com/1555215/228729552-0de3ef4b-5783-4288-a56f-1c7f5d23235f.png">

This PR fixes the custom_field bug.