### PR TITLE
FEATURE: add topic_unvote event to trigger topic_voting webhook

### DIFF
--- a/app/controllers/discourse_topic_voting/votes_controller.rb
+++ b/app/controllers/discourse_topic_voting/votes_controller.rb
@@ -70,6 +70,16 @@ module DiscourseTopicVoting
         votes_left: [(current_user.vote_limit - current_user.vote_count), 0].max,
       }
 
+      if WebHook.active_web_hooks(:topic_voting).exists?
+        payload = {
+          topic_id: topic_id,
+          topic_slug: topic.slug,
+          voter_id: current_user.id,
+          vote_count: obj[:vote_count],
+        }
+        WebHook.enqueue_topic_voting_hooks(:topic_unvote, topic, payload.to_json)
+      end
+
       render json: obj
     end
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -47,4 +47,4 @@ en:
       web_hooks:
         topic_voting_event:
           name: "Topic Voting Event"
-          details: "When a topic receives an upvote"
+          details: "When a user votes or unvotes on a topic"


### PR DESCRIPTION
- Adds a new `topic_unvote` event which triggers the `topic_voting` webhook when a user unvotes the post
- Changes the description for the webhook to reflect the new trigger
- Adds a test for the new `topic_unvote` event