### PR TITLE
DEV: Pass respect_plugin_enabled to add_to_serializer as keyword argument

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -95,7 +95,7 @@ after_initialize do
     end
   end
 
-  add_to_serializer(:category, :custom_fields, false) do
+  add_to_serializer(:category, :custom_fields, respect_plugin_enabled: false) do
     return object.custom_fields if !SiteSetting.voting_enabled
 
     object.custom_fields.merge(


### PR DESCRIPTION
### What is this change?

Passing the `respect_plugin_enabled` argument to `#add_to_serializer` as a positional argument is deprecated. It is now expected to be a keyword argument. This PR adds the keyword.