### PR TITLE
FIX: use safe navigation operator for params

### DIFF
--- a/lib/discourse_topic_voting/categories_controller_extension.rb
+++ b/lib/discourse_topic_voting/categories_controller_extension.rb
@@ -4,7 +4,7 @@ module DiscourseTopicVoting
   module CategoriesControllerExtension
     def category_params
       @vote_enabled ||=
-        !!ActiveRecord::Type::Boolean.new.cast(params[:custom_fields][:enable_topic_voting])
+        !!ActiveRecord::Type::Boolean.new.cast(params&.[](:custom_fields)&.[](:enable_topic_voting))
 
       category_params = super
 

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -46,7 +46,7 @@ describe CategoriesController do
   end
 
   it "works fine when `custom_fields` isn't passed " do
-    put "/categories/#{category.id}.json", params: {hello: "world"}
+    put "/categories/#{category.id}.json", params: { hello: "world" }
     expect(response.status).to eq(200)
   end
 end

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -44,4 +44,9 @@ describe CategoriesController do
         }
     expect(Category.can_vote?(category.id)).to eq(false)
   end
+
+  it "works fine when `custom_fields` isn't passed " do
+    put "/categories/#{category.id}.json", params: {hello: "world"}
+    expect(response.status).to eq(200)
+  end
 end


### PR DESCRIPTION
Bug report: https://meta.discourse.org/t/-/289850
Solution ref: https://stackoverflow.com/questions/34794697

`custom_fields` might not be passed if the request is via API. We need to handle the case so that there's no error thrown(NoMethodError is being thrown currently).

I didn't include a test case because its not simple to test. Using `put` inside `expect {}` doesn't raise the error in the controller up to the invocation it seems?