### PR TITLE
FIX: merge votes regardless of voters' visibility

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -173,8 +173,9 @@ after_initialize do
     moved_votes = 0
     duplicated_votes = 0
 
-    if orig.who_voted.present? && orig.closed
-      orig.who_voted.each do |user|
+    who_voted = orig.votes.map(&:user)
+    if who_voted.present? && orig.closed
+      who_voted.each do |user|
         next if user.blank?
 
         user_votes = user.topics_with_vote.pluck(:topic_id)

--- a/spec/voting_spec.rb
+++ b/spec/voting_spec.rb
@@ -36,6 +36,9 @@ describe DiscourseTopicVoting do
     let(:users) { [user0, user1, user2, user3, user4, user5] }
 
     before do
+      # ensure merging votes works regardless of voters' visibility
+      SiteSetting.voting_show_who_voted = false
+
       Fabricate(:post, topic: topic0, user: user0)
       Fabricate(:post, topic: topic0, user: user0)
 


### PR DESCRIPTION
Ensures merging topics also merge votes regardless of the voters' visibility (when `voting_show_who_voted` site setting is `false`), bypassing this check from the previously used `orig.who_voted`:

https://github.com/discourse/discourse-topic-voting/blob/f9654ee1b6342ed1a11c23003bcb4a05b6f3c9e9/lib/discourse_topic_voting/topic_extension.rb#L48-L52