### PR TITLE
DEV: Update deprecated Font Awesome icon names

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,3 +1,4 @@
+< 3.4.0.beta2-dev: 6d52b8cfa8b3e2920aa3f12fc52673b88f53f776
 < 3.4.0.beta1-dev: 4ebcd1187b59290b79db8c61c89df9f72bf1363c
 < 3.3.0.beta5-dev: fdb1f98a963adac049ffe9cd4fc506d77dd38cca
 < 3.3.0.beta1-dev: ba41633e0abe0535fd358a0809e0b4e0c79be128

--- a/assets/javascripts/discourse/widgets/remove-vote.js
+++ b/assets/javascripts/discourse/widgets/remove-vote.js
@@ -10,7 +10,7 @@ export default createWidget("remove-vote", {
   },
 
   html() {
-    return [iconNode("times"), I18n.t("topic_voting.remove_vote")];
+    return [iconNode("xmark"), I18n.t("topic_voting.remove_vote")];
   },
 
   click() {


### PR DESCRIPTION
This PR updates deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.