### PR TITLE
FEATURE: add "Votes" option to category topic list settings

### DIFF
--- a/assets/javascripts/discourse/initializers/discourse-topic-voting.js
+++ b/assets/javascripts/discourse/initializers/discourse-topic-voting.js
@@ -65,5 +65,19 @@ export default {
         api.addSearchSuggestion("order:votes");
       }
     });
+
+    withPluginApi("2.1.0", (api) => {
+      api.registerValueTransformer(
+        "category-available-views",
+        ({ value, context }) => {
+          if (context.customFields.enable_topic_voting) {
+            value.push({
+              name: i18n("filters.votes.title"),
+              value: "votes",
+            });
+          }
+        }
+      );
+    });
   },
 };


### PR DESCRIPTION
Along with https://github.com/discourse/discourse/pull/31264 — allows a category with voting enable to select "Votes" as the Default Topic List value. 


![image](https://github.com/user-attachments/assets/6a5833dc-1df6-4ab2-b639-a3490fa691ae)

![image](https://github.com/user-attachments/assets/954a053e-6742-4e7a-bc01-4c2e5fda1938)
